### PR TITLE
Fixed header define and MSG_NOSIGNAL bug for better portabilty

### DIFF
--- a/CPP/network/network.cpp
+++ b/CPP/network/network.cpp
@@ -73,7 +73,7 @@ string Network::receive()
 
 	while(true)
 	{
-		iReadBytes = recv(sock, buffer, sizeof(buffer), MSG_NOSIGNAL);
+		iReadBytes = recv(sock, buffer, sizeof(buffer), 0);
 
 		if(!iReadBytes > 0)
 		{

--- a/CPP/pushnotifier.h
+++ b/CPP/pushnotifier.h
@@ -1,5 +1,5 @@
 #ifndef PUSHNOTIFIER_H
-#define PUSHNOTIFiER_H
+#define PUSHNOTIFIER_H
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
Tiny error in header file and MSG_NOSIGNAL bug was fixed. This leads to better portability for non linux users.